### PR TITLE
fix: cannot list resource pods

### DIFF
--- a/changelog.d/20230718_105008_regis_fix_k8s_vector_perms.md
+++ b/changelog.d/20230718_105008_regis_fix_k8s_vector_perms.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix "cannot list resource 'pods'" on Kubernetes. (by @regisb)

--- a/tutorcairn/patches/k8s-deployments
+++ b/tutorcairn/patches/k8s-deployments
@@ -2,7 +2,7 @@
 ####### Cairn plugin
 # log collection
 # https://vector.dev/docs/setup/installation/platforms/kubernetes/
-# https://github.com/timberio/vector/blob/master/distribution/kubernetes/vector-agent/resources.yaml
+# https://github.com/vectordotdev/vector/blame/master/distribution/kubernetes/vector-agent/rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -19,8 +19,11 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - namespaces
+      - nodes
       - pods
     verbs:
+      - list
       - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Looks like the vector container now requires new permissions. This was detected here: https://github.com/openedx/tutor-contrib-aspects/issues/180#issuecomment-1639147060