### PR TITLE
fix: Add CAIRN_HOST to CORS_ORIGIN_WHITELIST

### DIFF
--- a/tutorcairn/patches/openedx-lms-production-settings
+++ b/tutorcairn/patches/openedx-lms-production-settings
@@ -1,0 +1,1 @@
+CORS_ORIGIN_WHITELIST.append("{% if ENABLE_HTTPS %}https://{% else %}http://{% endif %}{{ CAIRN_HOST }}")


### PR DESCRIPTION
**Error:**
Not able to sign-in to superset due to CORS error
 [openedx.core.djangoapps.cors_csrf.helpers] [user 39] [ip 192.168.65.1] helpers.py:64 - Origin 'http://data.local.overhang.io' was not in `CORS_ORIGIN_WHITELIST`; full referer was 'http://data.local.overhang.io/' and requested host was 'local.overhang.io'; CORS_ORIGIN_ALLOW_ALL=False