### PR TITLE
Enhancement: Update User Activity Query

### DIFF
--- a/changelog.d/20240405_151230_fahad.khalid.md
+++ b/changelog.d/20240405_151230_fahad.khalid.md
@@ -1,0 +1,1 @@
+- [Improvement] Update User Activity dataset query to improve average time spent in course. (by @Fahadkhalid210)

--- a/changelog.d/20240405_151230_fahad.khalid.md
+++ b/changelog.d/20240405_151230_fahad.khalid.md
@@ -1,1 +1,1 @@
-- [Improvement] Update User Activity dataset query to improve average time spent in course. (by @Fahadkhalid210)
+- [Improvement] Update User Activity dataset query by extending time span to 120 seconds and selecting all events where course ID is not null to improve average time spent in course. (by @Fahadkhalid210)

--- a/tutorcairn/templates/cairn/apps/superset/bootstrap/courseoverview.json
+++ b/tutorcairn/templates/cairn/apps/superset/bootstrap/courseoverview.json
@@ -1909,7 +1909,7 @@
                 "offset": 0,
                 "params": "{\"remote_id\": 49, \"database_name\": \"admin\"}",
                 "schema": "openedx",
-                "sql": "SELECT user_id,\n  course_id,\n  time,\n  arrayJoin(range(floor(toUInt64(toUnixTimestamp(time) - 5)), ceil(toUInt64(toUnixTimestamp(time) + 5)))) AS timestamp\nFROM events\nWHERE event_source = 'browser'",
+                "sql": "SELECT user_id,\n  course_id,\n  time,\n  arrayJoin(range(floor(toUInt64(toUnixTimestamp(time))), ceil(toUInt64(toUnixTimestamp(time) + 120)))) AS timestamp\nFROM events\nWHERE course_id <> '' and user_id > 0",
                 "table_name": "User activity",
                 "template_params": null
             }


### PR DESCRIPTION
update user activity query to improve average time spent in course

### Description:
In our ongoing analysis of **PT** data, we've identified discrepancies in the time spent by users in courses. Additionally, relying solely on "browser" events for these calculations has proven insufficient. After thorough investigation, we've determined that extending the time span from 10 seconds to 120 seconds and selecting all events where the course ID is not null provides a more accurate representation of the time users spend in courses. 

Therefore, this pull request updates the query to enhance the accuracy of the average time spent in courses.

**Before:** 
<img width="393" alt="image" src="https://github.com/overhangio/tutor-cairn/assets/79192414/70db7742-f825-4a20-b3e1-a95d0f338512">

**After:**
![image](https://github.com/overhangio/tutor-cairn/assets/79192414/741df61d-e9e6-49e2-9121-36cf26d95e19)
