### PR TITLE
added cors for Embeded Dashboards

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -244,7 +244,15 @@ Add/Update Superset Configurations
 ----------------------------------
 
 Use ``cairn-superset-settings`` patch to add or update `Superset configurations <https://github.com/apache/superset/blob/master/superset/config.py>`__.
+
+e.g, to customize visualizations, add following configurations in ``cairn-superset-settings`` patch::
+
+    APP_NAME = "<APP_NAME>"
+    APP_ICON = "<APP_ICON>"
+    APP_ICON_WIDTH = <APP_ICON_WIDTH>
+
 Then apply changes with::
+    
     tutor local launch
 
 Troubleshooting

--- a/README.rst
+++ b/README.rst
@@ -240,6 +240,13 @@ Postgresql/Superset settings
 - ``CAIRN_POSTGRESQL_PASSWORD`` (default: ``"{{ 20|random_string }}"``): Postgresql password.
 - ``CAIRN_SUPERSET_SECRET_KEY`` (default: ``"{{ 20|random_string }}"``): randomly-generated secret key for the Superset frontend.
 
+Add/Update Superset Configurations
+----------------------------------
+
+Use ``cairn-superset-settings`` patch to add or update `Superset configurations <https://github.com/apache/superset/blob/master/superset/config.py>`__.
+Then apply changes with::
+    tutor local launch
+
 Troubleshooting
 ---------------
 

--- a/changelog.d/20240416_165758_fahad.khalid.md
+++ b/changelog.d/20240416_165758_fahad.khalid.md
@@ -1,0 +1,1 @@
+- [Improvement] Added CORS for embeded Dashboards. (by @Fahadkhalid210)

--- a/tutorcairn/templates/cairn/apps/superset/superset_config.py
+++ b/tutorcairn/templates/cairn/apps/superset/superset_config.py
@@ -162,4 +162,13 @@ FEATURE_FLAGS = {
     "EMBEDDED_SUPERSET": True
 }
 
+# Embedded Dashboard CORS
+ENABLE_CORS=True
+CORS_OPTIONS={
+    "supports_credentials": True,
+    "allow_headers": ["*"],
+    "resources": ["*"],
+    'origins': ["{{ LMS_HOST }}","{{ CMS_HOST }}"],
+}
+
 {{ patch("cairn-superset-settings") }}

--- a/tutorcairn/templates/cairn/apps/superset/superset_config.py
+++ b/tutorcairn/templates/cairn/apps/superset/superset_config.py
@@ -163,12 +163,17 @@ FEATURE_FLAGS = {
 }
 
 # Embedded Dashboard CORS
+OPENEDX_CMS_ROOT_URL = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ CMS_HOST }}"
+
+if os.environ.get("FLASK_ENV") == "development":
+    OPENEDX_CMS_ROOT_URL = "http://{{ CMS_HOST }}:8001"
+
 ENABLE_CORS=True
 CORS_OPTIONS={
-    "supports_credentials": True,
-    "allow_headers": ["*"],
-    "resources": ["*"],
-    'origins': ["{{ LMS_HOST }}","{{ CMS_HOST }}"],
+    "origins": [
+    f"{OPENEDX_LMS_ROOT_URL}", 
+    f"{OPENEDX_CMS_ROOT_URL}"
+    ],
 }
 
 {{ patch("cairn-superset-settings") }}

--- a/tutorcairn/templates/cairn/apps/superset/superset_config.py
+++ b/tutorcairn/templates/cairn/apps/superset/superset_config.py
@@ -84,6 +84,12 @@ RESULTS_BACKEND = RedisCache(
     db=REDIS_CACHE_DB,
     key_prefix="superset_results",
 )
+OPENEDX_LMS_ROOT_URL = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
+OPENEDX_CMS_ROOT_URL = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ CMS_HOST }}"
+
+if os.environ.get("FLASK_ENV") == "development":
+    OPENEDX_LMS_ROOT_URL = "http://{{ LMS_HOST }}:8000"
+    OPENEDX_CMS_ROOT_URL = "http://{{ CMS_HOST }}:8001"
 
 {% if CAIRN_ENABLE_SSO %}
 # Authentication
@@ -91,10 +97,9 @@ RESULTS_BACKEND = RedisCache(
 # https://flask-appbuilder.readthedocs.io/en/latest/security.html#authentication-oauth
 from flask_appbuilder.security.manager import AUTH_OAUTH
 AUTH_TYPE = AUTH_OAUTH
-OPENEDX_LMS_ROOT_URL = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
+
 OPENEDX_SSO_CLIENT_ID = "{{ CAIRN_SSO_CLIENT_ID }}"
 if os.environ.get("FLASK_ENV") == "development":
-    OPENEDX_LMS_ROOT_URL = "http://{{ LMS_HOST }}:8000"
     OPENEDX_SSO_CLIENT_ID = "{{ CAIRN_SSO_CLIENT_ID }}-dev"
 OAUTH_PROVIDERS = [
     {
@@ -161,12 +166,6 @@ FEATURE_FLAGS = {
     # Enable dashboard embedding
     "EMBEDDED_SUPERSET": True
 }
-
-# Embedded Dashboard CORS
-OPENEDX_CMS_ROOT_URL = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ CMS_HOST }}"
-
-if os.environ.get("FLASK_ENV") == "development":
-    OPENEDX_CMS_ROOT_URL = "http://{{ CMS_HOST }}:8001"
 
 ENABLE_CORS=True
 CORS_OPTIONS={


### PR DESCRIPTION
Added CORS for embeded Dashboards

### Description:
This PR adds support for Cross-Origin Resource Sharing (CORS) to enable the embedding of Dashboards from Superset Cairn into LMS/CMS site. This enhancement allows us to seamlessly integrate visual analytics and data-driven insights directly within our platform.

For context: [Discussion Link](https://discuss.openedx.org/t/cairn-how-to-embed-dashboard-from-superset-cairn-into-lms-site/12443)

Solution suggested in the Superset: [Solution](https://github.com/apache/superset/issues/20425#issuecomment-1433236941)