### PR TITLE
feat: support microseconds DateTime64(6) fields via Vector sink

### DIFF
--- a/tutorcairn/templates/cairn/apps/vector/partials/common-post.toml
+++ b/tutorcairn/templates/cairn/apps/vector/partials/common-post.toml
@@ -50,8 +50,9 @@ encoding.only_fields = ["time", "message.context.course_id", "message.context.us
 # # Send logs to clickhouse
 [sinks.clickhouse]
 type = "clickhouse"
-# Required: https://github.com/timberio/vector/issues/5797
-encoding.timestamp_format = "unix"
+# support time field with microseconds
+date_time_best_effort = true
+encoding.timestamp_format = "rfc3339"
 inputs = ["tracking"]
 endpoint = "{{ CAIRN_CLICKHOUSE_HTTP_SCHEME }}://{{ CAIRN_CLICKHOUSE_HOST }}:{{ CAIRN_CLICKHOUSE_HTTP_PORT }}"
 database = "{{ CAIRN_CLICKHOUSE_DATABASE }}"


### PR DESCRIPTION
_incomplete PR as of now_

Use rfc3339 with date_time_best_effort
the Vector change is non-breaking... you can still store into plain DateTime if you don't want to change the columns to DateTime64

If you want to take this feature, let me know how you want to handle the migration part ( updating `time` columns to DateTime64(6) ) and I can help implement; i.e., single migration as 0014?  The tricky part is that you have to duplicate, insert from old to new, and drop the old tables to modify a column used as a key (`time` being the main ordering key in the tables).   

I've done that on an installation with 1.2B rows in _tracking but it's not a straightforward operation.

Re:  #42 

