### PR TITLE
feat: enable alerts and reports in superset

### DIFF
--- a/changelog.d/20250214_213025_danyal.faheem_enable_alerts_reports.md
+++ b/changelog.d/20250214_213025_danyal.faheem_enable_alerts_reports.md
@@ -1,0 +1,1 @@
+- [Improvement] Enable Alerts and Reports in superset. (by @Danyal-Faheem)

--- a/tutorcairn/templates/cairn/apps/superset/superset_config.py
+++ b/tutorcairn/templates/cairn/apps/superset/superset_config.py
@@ -142,10 +142,6 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
         },
     }
     CELERYBEAT_SCHEDULE = {
-        "email_reports.schedule_hourly": {
-            "task": "email_reports.schedule_hourly",
-            "schedule": crontab(minute=1, hour="*"),
-        },
         "reports.scheduler": {
             "task": "reports.scheduler",
             "schedule": crontab(minute="*", hour="*"),
@@ -159,13 +155,32 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
 
 CELERY_CONFIG = CeleryConfig
 
+# Email configuration
+SMTP_HOST = "{{ SMTP_HOST }}"
+SMTP_PORT = {{ SMTP_PORT }}
+SMTP_STARTTLS = {{ SMTP_USE_TLS }}
+SMTP_SSL = {{ SMTP_USE_SSL }}
+SMTP_USER = "{{ SMTP_USERNAME }}" # use the empty string "" if using an unauthenticated SMTP server
+SMTP_PASSWORD = "{{ SMTP_PASSWORD }}" # use the empty string "" if using an unauthenticated SMTP server
+SMTP_MAIL_FROM = "{{ CONTACT_EMAIL }}"
+EMAIL_REPORTS_SUBJECT_PREFIX = "[{{ PLATFORM_NAME }}] "
+
+ALERT_REPORTS_NOTIFICATION_DRY_RUN = False
+WEBDRIVER_BASEURL = "http://cairn-superset:8000/"
+# The base URL for the email report hyperlinks.
+WEBDRIVER_BASEURL_USER_FRIENDLY = "{{ CAIRN_HOST }}"
+
+WEBDRIVER_OPTION_ARGS = ["--headless"]
+
 # Avoid duplicate logging because of propagation to root logger
 logging.getLogger("superset").propagate = False
 
 # https://github.com/apache/superset/blob/master/RESOURCES/FEATURE_FLAGS.md
 FEATURE_FLAGS = {
     # Enable dashboard embedding
-    "EMBEDDED_SUPERSET": True
+    "EMBEDDED_SUPERSET": True,
+    "ALERT_REPORTS": True,
+    
 }
 
 ENABLE_CORS=True

--- a/tutorcairn/templates/cairn/apps/superset/superset_config.py
+++ b/tutorcairn/templates/cairn/apps/superset/superset_config.py
@@ -166,7 +166,7 @@ SMTP_MAIL_FROM = "{{ CONTACT_EMAIL }}"
 EMAIL_REPORTS_SUBJECT_PREFIX = "[{{ PLATFORM_NAME }}] "
 
 ALERT_REPORTS_NOTIFICATION_DRY_RUN = False
-WEBDRIVER_BASEURL = "http://cairn-superset:8000/"
+WEBDRIVER_BASEURL = "http://cairn-superset:2247/"
 # The base URL for the email report hyperlinks.
 WEBDRIVER_BASEURL_USER_FRIENDLY = "{{ CAIRN_HOST }}"
 

--- a/tutorcairn/templates/cairn/apps/superset/superset_config.py
+++ b/tutorcairn/templates/cairn/apps/superset/superset_config.py
@@ -128,7 +128,7 @@ AUTH_USER_REGISTRATION = True
 
 class CeleryConfig:  # pylint: disable=too-few-public-methods
     BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CELERY_DB}"
-    CELERY_IMPORTS = ("superset.sql_lab", "superset.tasks")
+    CELERY_IMPORTS = ("superset.sql_lab", "superset.tasks","superset.tasks.thumbnails",)
     CELERYD_LOG_LEVEL = "DEBUG"
     CELERYD_PREFETCH_MULTIPLIER = 1
     CELERY_ACKS_LATE = False
@@ -170,8 +170,6 @@ WEBDRIVER_BASEURL = "http://cairn-superset:8000/"
 # The base URL for the email report hyperlinks.
 WEBDRIVER_BASEURL_USER_FRIENDLY = "{{ CAIRN_HOST }}"
 
-WEBDRIVER_OPTION_ARGS = ["--headless"]
-
 # Avoid duplicate logging because of propagation to root logger
 logging.getLogger("superset").propagate = False
 
@@ -179,6 +177,8 @@ logging.getLogger("superset").propagate = False
 FEATURE_FLAGS = {
     # Enable dashboard embedding
     "EMBEDDED_SUPERSET": True,
+    # This feature is stable but known to have bugs from time to time
+    # Alerts and Reports also do not work on arm64 base images
     "ALERT_REPORTS": True,
     
 }

--- a/tutorcairn/templates/cairn/build/cairn-superset/Dockerfile
+++ b/tutorcairn/templates/cairn/build/cairn-superset/Dockerfile
@@ -7,15 +7,26 @@ FROM docker.io/apache/superset:4.0.0
 
 USER root
 
+# https://github.com/apache/superset/blob/4.0.0/Dockerfile#L109-L110
+# Extracted from https://superset.apache.org/docs/installation/alerts-reports/#custom-dockerfile
+ARG GECKODRIVER_VERSION=v0.33.0 \
+    FIREFOX_VERSION=117.0.1
+
 # https://pypi.org/project/clickhouse-driver/
 # https://pypi.org/project/mysqlclient/
 # https://pypi.org/project/clickhouse-connect/
 # https://pypi.org/project/clickhouse-sqlalchemy/
 # https://pypi.org/project/Authlib/
 # We preserve the clickhouse-sqlalchemy package to keep backward compatibility with existing dashboards
-RUN apt-get update \
-    && apt-get install -y \
-        pkg-config
+RUN apt-get update -qq \
+    && apt-get install -yqq --no-install-recommends wget bzip2 git \
+    # Mysql dependencies
+    default-libmysqlclient-dev build-essential pkg-config gcc \
+    && wget -q https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz -O - | tar xfz - -C /usr/local/bin \
+    # Install Firefox
+    && wget -q https://download-installer.cdn.mozilla.net/pub/firefox/releases/${FIREFOX_VERSION}/linux-x86_64/en-US/firefox-${FIREFOX_VERSION}.tar.bz2 -O - | tar xfj - -C /opt \
+    && ln -s /opt/firefox/firefox /usr/local/bin/firefox \
+    && apt-get autoremove -yqq --purge wget bzip2 && rm -rf /var/[log,tmp]/* /tmp/* /var/lib/apt/lists/*
 
 RUN --mount=type=cache,target=/root/.cache/pip,sharing=shared pip install \
     clickhouse-driver==0.2.7 \

--- a/tutorcairn/templates/cairn/build/cairn-superset/Dockerfile
+++ b/tutorcairn/templates/cairn/build/cairn-superset/Dockerfile
@@ -12,22 +12,29 @@ USER root
 ARG GECKODRIVER_VERSION=v0.33.0 \
     FIREFOX_VERSION=117.0.1
 
+RUN apt-get update -qq \
+    && apt-get install -yqq --no-install-recommends \
+        libnss3 \
+        libdbus-glib-1-2 \
+        libgtk-3-0 \
+        libx11-xcb1 \
+        libasound2 \
+        libxtst6 \
+        wget \
+        pkg-config \
+    # Install GeckoDriver WebDriver
+    && wget -q https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz -O - | tar xfz - -C /usr/local/bin \
+    # Install Firefox
+    && wget -q https://download-installer.cdn.mozilla.net/pub/firefox/releases/${FIREFOX_VERSION}/linux-x86_64/en-US/firefox-${FIREFOX_VERSION}.tar.bz2 -O - | tar xfj - -C /opt \
+    && ln -s /opt/firefox/firefox /usr/local/bin/firefox \
+    && apt-get autoremove -yqq --purge wget && rm -rf /var/[log,tmp]/* /tmp/* /var/lib/apt/lists/*
+
 # https://pypi.org/project/clickhouse-driver/
 # https://pypi.org/project/mysqlclient/
 # https://pypi.org/project/clickhouse-connect/
 # https://pypi.org/project/clickhouse-sqlalchemy/
 # https://pypi.org/project/Authlib/
 # We preserve the clickhouse-sqlalchemy package to keep backward compatibility with existing dashboards
-RUN apt-get update -qq \
-    && apt-get install -yqq --no-install-recommends wget bzip2 git \
-    # Mysql dependencies
-    default-libmysqlclient-dev build-essential pkg-config gcc \
-    && wget -q https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux64.tar.gz -O - | tar xfz - -C /usr/local/bin \
-    # Install Firefox
-    && wget -q https://download-installer.cdn.mozilla.net/pub/firefox/releases/${FIREFOX_VERSION}/linux-x86_64/en-US/firefox-${FIREFOX_VERSION}.tar.bz2 -O - | tar xfj - -C /opt \
-    && ln -s /opt/firefox/firefox /usr/local/bin/firefox \
-    && apt-get autoremove -yqq --purge wget bzip2 && rm -rf /var/[log,tmp]/* /tmp/* /var/lib/apt/lists/*
-
 RUN --mount=type=cache,target=/root/.cache/pip,sharing=shared pip install \
     clickhouse-driver==0.2.7 \
     mysqlclient==2.2.4 \


### PR DESCRIPTION
fixes #46.

We enable the option of alerts and reports in superset. We use the firefox and gecko webdriver for screenshots of reports.