### PR TITLE
fix: do not add cairn-postgresql and cairn-clickhouse dependencies when they are running externally

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -237,6 +237,8 @@ Postgresql/Superset settings
 - ``CAIRN_RUN_POSTGRESQL`` (default: ``true``): set to ``false`` to run your own Postgresql cluster separately from Cairn. Postgresql is the database that stores all data related to Superset, which is the Cairn frontend.
 - ``CAIRN_SUPERSET_LANGUAGE_CODE`` (default: ``"{{ LANGUAGE_CODE[:2] }}"``): 2-letter code of the default language for the Superset frontend. View the list of all supported languages `here <https://github.com/apache/superset/blob/dc575080d7e43d40b1734bb8f44fdc291cb95b11/superset/config.py#L324>`__. When different than "en", users will have the opportunity to switch from English to this language via a flag icon in the top-right corner.
 - ``CAIRN_SUPERSET_DOCKER_IMAGE`` (default: ``"{{ DOCKER_REGISTRY }}overhangio/cairn-superset:{{ CAIRN_VERSION }}"``): name of the Docker image that runs Postgresql.
+- ``CAIRN_POSTGRESQL_HOST`` (default: ``"cairn-postgresql"``): Host address of the Postgresql database.
+- ``CAIRN_POSTGRESQL_PORT`` (default: ``5432``): Postgresql port.
 - ``CAIRN_POSTGRESQL_DATABASE`` (default: ``"superset"``): name of the Postgresql database.
 - ``CAIRN_POSTGRESQL_USERNAME`` (default: ``"superset"``): Postgresql username.
 - ``CAIRN_POSTGRESQL_PASSWORD`` (default: ``"{{ 20|random_string }}"``): Postgresql password.

--- a/changelog.d/20250314_131458_danyal.faheem_fix_external_postgres_dependency.md
+++ b/changelog.d/20250314_131458_danyal.faheem_fix_external_postgres_dependency.md
@@ -1,2 +1,3 @@
 - [Bugfix] Do not add cairn-postgresql as a dependency when CAIRN_RUN_POSTGRESQL is false. (by @Danyal-Faheem)
+- [Bugfix] Add missing CAIRN_POSTGRESQL_HOST and CAIRN_POSTGRESQL_PORT settings to allow usage with external postgresql dbs. (by @Danyal-Faheem)
 - [Bugfix] Do not manage cairn-clickhouse permissions CAIRN_RUN_CLICKHOUSE is false. (by @Danyal-Faheem)

--- a/changelog.d/20250314_131458_danyal.faheem_fix_external_postgres_dependency.md
+++ b/changelog.d/20250314_131458_danyal.faheem_fix_external_postgres_dependency.md
@@ -1,0 +1,2 @@
+- [Bugfix] Do not add cairn-postgresql as a dependency when CAIRN_RUN_POSTGRESQL is false. (by @Danyal-Faheem)
+- [Bugfix] Do not manage cairn-clickhouse permissions CAIRN_RUN_CLICKHOUSE is false. (by @Danyal-Faheem)

--- a/tutorcairn/patches/local-docker-compose-jobs-services
+++ b/tutorcairn/patches/local-docker-compose-jobs-services
@@ -23,7 +23,7 @@ cairn-superset-job:
         disable: true
     depends_on:
         {% if RUN_REDIS %}- redis{% endif %}
-        - cairn-postgresql
+        {% if CAIRN_RUN_POSTGRESQL %}- cairn-postgresql{% endif %}
 cairn-openedx-job:
     image: {{ DOCKER_IMAGE_OPENEDX }}
     environment:

--- a/tutorcairn/patches/local-docker-compose-permissions-command
+++ b/tutorcairn/patches/local-docker-compose-permissions-command
@@ -1,2 +1,2 @@
-setowner 1000 /data/cairn-clickhouse
+{% if CAIRN_RUN_CLICKHOUSE %}setowner 1000 /data/cairn-clickhouse{% endif %}
 {% if CAIRN_RUN_POSTGRESQL %}setowner 70 /data/cairn-postgresql{% endif %}

--- a/tutorcairn/patches/local-docker-compose-permissions-volumes
+++ b/tutorcairn/patches/local-docker-compose-permissions-volumes
@@ -1,2 +1,2 @@
-- ../../data/cairn/clickhouse:/data/cairn-clickhouse
+{% if CAIRN_RUN_CLICKHOUSE %}- ../../data/cairn/clickhouse:/data/cairn-clickhouse{% endif %}
 {% if CAIRN_RUN_POSTGRESQL %}- ../../data/cairn/postgresql:/data/cairn-postgresql{% endif %}

--- a/tutorcairn/patches/local-docker-compose-services
+++ b/tutorcairn/patches/local-docker-compose-services
@@ -42,7 +42,7 @@ cairn-superset:
     restart: unless-stopped
     depends_on:
         {% if RUN_REDIS %}- redis{% endif %}
-        - cairn-postgresql
+        {% if CAIRN_RUN_POSTGRESQL %}- cairn-postgresql{% endif %}
 cairn-superset-worker:
     image: {{ CAIRN_SUPERSET_DOCKER_IMAGE }}
     volumes:
@@ -56,7 +56,7 @@ cairn-superset-worker:
         disable: true
     depends_on:
         {% if RUN_REDIS %}- redis{% endif %}
-        - cairn-postgresql
+        {% if CAIRN_RUN_POSTGRESQL %}- cairn-postgresql{% endif %}
 cairn-superset-worker-beat:
     image: {{ CAIRN_SUPERSET_DOCKER_IMAGE }}
     volumes:
@@ -70,7 +70,7 @@ cairn-superset-worker-beat:
         disable: true
     depends_on:
         {% if RUN_REDIS %}- redis{% endif %}
-        - cairn-postgresql
+        {% if CAIRN_RUN_POSTGRESQL %}- cairn-postgresql{% endif %}
 {% if CAIRN_RUN_POSTGRESQL %}
 cairn-postgresql:
     image: docker.io/postgres:9.6-alpine

--- a/tutorcairn/plugin.py
+++ b/tutorcairn/plugin.py
@@ -34,6 +34,8 @@ config: t.Dict[str, t.Dict[str, t.Any]] = {
         "CLICKHOUSE_USERNAME": "openedx",
         # Superset/Postgresql
         "RUN_POSTGRESQL": True,
+        "POSTGRESQL_HOST": "cairn-postgresql",
+        "POSTGRESQL_PORT": "5432",
         "POSTGRESQL_DATABASE": "superset",
         "POSTGRESQL_USERNAME": "superset",
         "SUPERSET_DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}overhangio/cairn-superset:{{ CAIRN_VERSION }}",

--- a/tutorcairn/templates/cairn/apps/superset/superset_config.py
+++ b/tutorcairn/templates/cairn/apps/superset/superset_config.py
@@ -11,7 +11,7 @@ from superset.cairn import sso as cairn_sso
 
 # https://superset.apache.org/docs/installation/configuring-superset
 SECRET_KEY = "{{ CAIRN_SUPERSET_SECRET_KEY }}"
-SQLALCHEMY_DATABASE_URI = "postgresql+psycopg2://{{ CAIRN_POSTGRESQL_USERNAME }}:{{ CAIRN_POSTGRESQL_PASSWORD }}@cairn-postgresql/{{ CAIRN_POSTGRESQL_DATABASE }}"
+SQLALCHEMY_DATABASE_URI = "postgresql+psycopg2://{{ CAIRN_POSTGRESQL_USERNAME }}:{{ CAIRN_POSTGRESQL_PASSWORD }}@{{ CAIRN_POSTGRESQL_HOST }}:{{ CAIRN_POSTGRESQL_PORT }}/{{ CAIRN_POSTGRESQL_DATABASE }}"
 
 # Caddy is running behind a proxy: Superset needs to handle x-forwarded-* headers
 # https://flask.palletsprojects.com/en/latest/deploying/proxy_fix/


### PR DESCRIPTION
This issue was originally created [here](https://discuss.openedx.org/t/issue-connecting-cairn-to-an-external-postgresql-database-in-tutor-mac-m3/15244).

The `cairn-postgresql` service was being added as a dependency for cairn-superset even when `CAIRN_RUN_POSTGRESQL` was set to False. This resulted in an error of:

```
service "cairn-superset" depends on undefined service "cairn-postgresql": invalid compose project
```

We therefore only add the dependency conditionally now.

Similarly, for cairn-clickhouse, the permissions command and volumes patches were being applied even when `CAIRN_RUN_CLICKHOUSE` was set to false. This did not result in any errors per se but was unnecessary.