### PR TITLE
fix: lms.startup -> django.setup in import courses script

### DIFF
--- a/tutorcairn/templates/cairn/apps/openedx/scripts/importcoursedata.py
+++ b/tutorcairn/templates/cairn/apps/openedx/scripts/importcoursedata.py
@@ -8,9 +8,9 @@ import requests
 # https://mysqlclient.readthedocs.io/user_guide.html#mysql-c-api-function-mapping
 from MySQLdb._mysql import escape_string as sql_escape_string
 
-import lms.startup
+import django
 
-lms.startup.run()
+django.setup()
 
 from lms.djangoapps.courseware.courses import get_course
 from xmodule.modulestore.django import modulestore


### PR DESCRIPTION
This PR fixes part of https://github.com/overhangio/tutor/issues/1207 and is based on https://github.com/overhangio/tutor/pull/1202
lms.startup has been removed as of https://github.com/openedx/edx-platform/pull/36302.
Therefore, we move to the original django.setup now.