### PR TITLE
fix: make superset ports consistent in local and dev

### DIFF
--- a/changelog.d/20250326_155128_danyal.faheem_make_ports_consistent.md
+++ b/changelog.d/20250326_155128_danyal.faheem_make_ports_consistent.md
@@ -1,0 +1,1 @@
+- [Improvement] Make superset ports consistent on local and dev by running it on 2247 in both environments. (by @Danyal-Faheem)

--- a/tutorcairn/patches/caddyfile
+++ b/tutorcairn/patches/caddyfile
@@ -1,4 +1,4 @@
 # Cairn
 {{ CAIRN_HOST }}{$default_site_port} {
-    reverse_proxy cairn-superset:8000
+    reverse_proxy cairn-superset:2247
 }

--- a/tutorcairn/patches/k8s-services
+++ b/tutorcairn/patches/k8s-services
@@ -39,7 +39,7 @@ metadata:
 spec:
   type: NodePort
   ports:
-    - port: 8000
+    - port: 2247
       protocol: TCP
   selector:
     app.kubernetes.io/name: cairn-superset

--- a/tutorcairn/templates/cairn/build/cairn-superset/Dockerfile
+++ b/tutorcairn/templates/cairn/build/cairn-superset/Dockerfile
@@ -30,11 +30,11 @@ USER superset
 COPY --chown=superset:superset ./cairn /app/superset/cairn
 
 # This is required to have a proper healthcheck
-ENV SUPERSET_PORT=8000
+ENV SUPERSET_PORT=2247
 
 ENTRYPOINT []
 CMD gunicorn \
-    --bind  "0.0.0.0:8000" \
+    --bind  "0.0.0.0:2247" \
     --access-logfile '-' \
     --error-logfile '-' \
     --workers 2 \


### PR DESCRIPTION
Superset was running on 2247 port in dev mode and on 8000 in local mode.
We now make this consistent so that superset runs on 2247 in both local and dev.