### PR TITLE
docs: Update edx.rtd links to docs.openedx.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Cairn vs alternatives
 ---------------------
 
 ========================================== =====  ===================================================================================  ===================================================
-List of features                           Cairn  `Open edX Insights <https://edx.readthedocs.io/projects/edx-insights/en/latest/>`__  `Figures <https://github.com/appsembler/figures>`__
+List of features                           Cairn  `Open edX Insights <https://docs.openedx.org/en/latest/site_ops/install_configure_run_guide/insights/index.html>`__  `Figures <https://github.com/appsembler/figures>`__
 ========================================== =====  ===================================================================================  ===================================================
 Event aggregation                            ✅      ✅                                                                                    ❌
 Real-time data                               ✅      ❌                                                                                    ✅


### PR DESCRIPTION
With the move to docs.openedx.org, update outdated reference links.

Ref: https://github.com/openedx/docs.openedx.org/issues/988