### PR TITLE
test: verify python package distribution build when running make test 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SRC_DIRS = ./tutorcairn
 BLACK_OPTS = --exclude templates ${SRC_DIRS}
 
 # Warning: These checks are not necessarily run on every PR.
-test: test-lint test-types test-format  # Run some static checks.
+test: test-lint test-types test-format test-pythonpackage  # Run some static checks.
 
 test-format: ## Run code formatting tests
 	black --check --diff $(BLACK_OPTS)
@@ -14,6 +14,12 @@ test-lint: ## Run code linting tests
 
 test-types: ## Run type checks.
 	mypy --exclude=templates --ignore-missing-imports --implicit-reexport --strict ${SRC_DIRS}
+
+build-pythonpackage: ## Build the "tutor-cairn" python package for upload to pypi
+	python -m build --sdist
+
+test-pythonpackage: build-pythonpackage ## Test that package can be uploaded to pypi
+	twine check dist/tutor_cairn-$(shell make version).tar.gz
 
 format: ## Format code automatically
 	black $(BLACK_OPTS)
@@ -26,6 +32,9 @@ changelog-entry: ## Create a new changelog entry.
 
 changelog: ## Collect changelog entries in the CHANGELOG.md file.
 	scriv collect
+
+version: ## Print the current tutor-cairn version
+	@python -c 'import io, os; about = {}; exec(io.open(os.path.join("tutorcairn", "__about__.py"), "rt", encoding="utf-8").read(), about); print(about["__version__"])'
 
 ESCAPE = 
 help: ## Print this help

--- a/changelog.d/20250408_141332_danyal.faheem_twine_build_ci.md
+++ b/changelog.d/20250408_141332_danyal.faheem_twine_build_ci.md
@@ -1,0 +1,1 @@
+- [Improvement] Test python package distribution build when running make test as well. (by @Danyal-Faheem)

--- a/changelog.d/20250408_141332_danyal.faheem_twine_build_ci.md
+++ b/changelog.d/20250408_141332_danyal.faheem_twine_build_ci.md
@@ -1,1 +1,1 @@
-- [Improvement] Test python package distribution build when running make test as well. (by @Danyal-Faheem)
+- [Improvement] Test python package distribution build when running make test. (by @Danyal-Faheem)


### PR DESCRIPTION
This is a recurring issue that we usually face whenever a new release is created and didn't show up in the existing CI.