### PR TITLE
fix: remove deprecated filter_scopes from import_dashboard script

### DIFF
--- a/changelog.d/20250409_153019_danyal.faheem_fix_breaking_dashboard_import.md
+++ b/changelog.d/20250409_153019_danyal.faheem_fix_breaking_dashboard_import.md
@@ -1,0 +1,1 @@
+- [Bugfix] Remove deprecated filter_scopes from import_dashboard script. (by @Danyal-Faheem)

--- a/tutorcairn/templates/cairn/build/cairn-superset/cairn/ctl.py
+++ b/tutorcairn/templates/cairn/build/cairn-superset/cairn/ctl.py
@@ -229,20 +229,6 @@ def import_dashboard(data, user, database):
 
         # Update filter mapping
         metadata = json.loads(dashboard.json_metadata)
-        new_filter_scopes = {}
-        for old_slice_id, filter_scope in metadata["filter_scopes"].items():
-            new_filter_scope = {}
-            for filter_name, properties in filter_scope.items():
-                properties["immune"] = [
-                    old_to_new_slice_id_map[old_immune_id]
-                    for old_immune_id in properties["immune"]
-                ]
-                new_filter_scope[filter_name] = properties
-            # Note that filter scope keys are str, not int
-            new_filter_scopes[
-                str(old_to_new_slice_id_map[int(old_slice_id)])
-            ] = new_filter_scope
-        metadata["filter_scopes"] = new_filter_scopes
         dashboard.json_metadata = json.dumps(metadata)
 
         # Load dashboard


### PR DESCRIPTION
Reference issue: https://github.com/overhangio/tutor-cairn/pull/53/files\#r2034772248 
Filter_scopes have been [deprecated](https://github.com/apache/superset/issues/24867) as of Superset 4.0.0.
We have also migrated away from filter box to native filters as of #53.

Therefore, we no longer require to add filter_scopes to the metadata anymore.