### PR TITLE
feat: migrate from pylint/black to ruff

### DIFF
--- a/.hatch_build.py
+++ b/.hatch_build.py
@@ -18,5 +18,5 @@ def load_about() -> dict[str, str]:
     with open(
         os.path.join(HERE, "tutorcairn", "__about__.py"), "rt", encoding="utf-8"
     ) as f:
-        exec(f.read(), about)  # pylint: disable=exec-used
+        exec(f.read(), about)
     return about

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,15 @@
 .DEFAULT_GOAL := help
 .PHONY: docs
 SRC_DIRS = ./tutorcairn
-BLACK_OPTS = --exclude templates ${SRC_DIRS}
 
 # Warning: These checks are not necessarily run on every PR.
-test: test-lint test-types test-format test-pythonpackage  # Run some static checks.
+test: test-lint test-format test-types test-pythonpackage  # Run some static checks.
 
 test-format: ## Run code formatting tests
-	black --check --diff $(BLACK_OPTS)
+	ruff format --check --diff ${SRC_DIRS}
 
 test-lint: ## Run code linting tests
-	pylint --errors-only --enable=unused-import,unused-argument --ignore=templates --ignore=docs/_ext ${SRC_DIRS}
+	ruff check ${SRC_DIRS}
 
 test-types: ## Run type checks.
 	mypy --exclude=templates --ignore-missing-imports --implicit-reexport --strict ${SRC_DIRS}
@@ -21,11 +20,11 @@ build-pythonpackage: ## Build the "tutor-cairn" python package for upload to pyp
 test-pythonpackage: build-pythonpackage ## Test that package can be uploaded to pypi
 	twine check dist/tutor_cairn-$(shell make version).tar.gz
 
-format: ## Format code automatically
-	black $(BLACK_OPTS)
+format: ## Format code 
+	ruff format ${SRC_DIRS}
 
-isort: ##  Sort imports. This target is not mandatory because the output may be incompatible with black formatting. Provided for convenience purposes.
-	isort --skip=templates ${SRC_DIRS}
+fix-lint: ## Fix lint errors automatically
+	ruff check --fix ${SRC_DIRS}
 
 changelog-entry: ## Create a new changelog entry.
 	scriv create

--- a/changelog.d/20250723_121728_danyal.faheem_migrate_ruff.md
+++ b/changelog.d/20250723_121728_danyal.faheem_migrate_ruff.md
@@ -1,0 +1,1 @@
+- [Improvement] Migrate from pylint and black to ruff. (by @Danyal-Faheem)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,14 @@ packages = ["tutorcairn"]
 exclude = ["templates", "docs/_ext"]
 
 [tool.ruff.lint]
+# E: pycodestyle errors
+# I: isort
+# N: pep8-naming
 select = ["E", "I", "N"]
+
+# F401: unused-import
+# F841: unused-variable
+# W292: missing-newline-at-end-of-file
 extend-select = ["F401", "F841", "W292"]
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,8 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
-  "tutor[dev]>=20.0.0,<21.0.0", 
-  "pylint", 
-  "black"
+  "tutor[dev]>=20.0.0,<21.0.0",
+  "ruff",
 ]
 
 [project.entry-points."tutor.plugin.v1"]
@@ -65,3 +64,12 @@ exclude = ["tests*"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["tutorcairn"]
+
+[tool.ruff]
+exclude = ["templates", "docs/_ext"]
+
+[tool.ruff.lint]
+select = ["E", "I", "N"]
+extend-select = ["F401", "F841", "W292"]
+
+[tool.ruff.format]

--- a/tutorcairn/plugin.py
+++ b/tutorcairn/plugin.py
@@ -25,7 +25,7 @@ config: t.Dict[str, t.Dict[str, t.Any]] = {
         "HOST": "data.{{ LMS_HOST }}",
         # Clickhouse
         "RUN_CLICKHOUSE": True,
-        "CLICKHOUSE_DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}overhangio/cairn-clickhouse:{{ CAIRN_VERSION }}",
+        "CLICKHOUSE_DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}overhangio/cairn-clickhouse:{{ CAIRN_VERSION }}",  # noqa: E501
         "CLICKHOUSE_HOST": "cairn-clickhouse",
         "CLICKHOUSE_HTTP_PORT": 8123,
         "CLICKHOUSE_HTTP_SCHEME": "http",
@@ -38,7 +38,7 @@ config: t.Dict[str, t.Dict[str, t.Any]] = {
         "POSTGRESQL_PORT": "5432",
         "POSTGRESQL_DATABASE": "superset",
         "POSTGRESQL_USERNAME": "superset",
-        "SUPERSET_DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}overhangio/cairn-superset:{{ CAIRN_VERSION }}",
+        "SUPERSET_DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}overhangio/cairn-superset:{{ CAIRN_VERSION }}",  # noqa: E501
         "SUPERSET_LANGUAGE_CODE": "{{ LANGUAGE_CODE[:2] }}",
         # SSO
         "ENABLE_SSO": True,
@@ -142,7 +142,7 @@ def _print_superset_host(
 @click.option(
     "-p",
     "--password",
-    help="Specify password from the command line. If undefined, no password will be set. (Ignored with SSO)",
+    help="Specify password from the command line. If undefined, no password will be set. (Ignored with SSO)",  # noqa: E501
     hide_input=True,
 )
 @click.option(
@@ -181,7 +181,7 @@ def create_user_command(
     if bootstrap_dashboards:
         yield (
             "cairn-superset",
-            f"python ./superset/cairn/ctl.py bootstrap-dashboards {username} /app/bootstrap/courseoverview.json",
+            f"python ./superset/cairn/ctl.py bootstrap-dashboards {username} /app/bootstrap/courseoverview.json",  # noqa: E501
         )
 
 

--- a/tutorcairn/templates/cairn/apps/superset/superset_config.py
+++ b/tutorcairn/templates/cairn/apps/superset/superset_config.py
@@ -126,7 +126,7 @@ AUTH_ROLES_SYNC_AT_LOGIN = {{ CAIRN_AUTH_ROLES_SYNC_AT_LOGIN }}
 AUTH_USER_REGISTRATION = True
 {% endif %}
 
-class CeleryConfig:  # pylint: disable=too-few-public-methods
+class CeleryConfig:
     BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_CELERY_DB}"
     CELERY_IMPORTS = ("superset.sql_lab", "superset.tasks","superset.tasks.thumbnails",)
     CELERYD_LOG_LEVEL = "DEBUG"


### PR DESCRIPTION
Linked Epic: https://github.com/overhangio/tutor/issues/1251

Some new rules that have been added are:

I: sort imports
N: check for pep8-naming standards
W292: check for missing extra line at EOF

Some of our lines, particularly in config break the 88 character line length limit. For that, we add a # noqa: E501 to let ruff know to ignore the rule for that line