### PR TITLE
chore: require the upcoming Tutor major version on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
+        env:
+          TARGET_BRANCH: ${{ github.base_ref || github.ref_name }}
         run: |
+          # On main this plugin requires the upcoming Tutor major version, which has
+          # no PyPI release yet: install Tutor from its main branch first.
+          if [ "$TARGET_BRANCH" = "main" ]; then
+            pip install "tutor[dev] @ git+https://github.com/overhangio/tutor@main"
+          fi
           pip install .[dev]
       - name: Test lint, types, and format
         run: make test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,14 +26,14 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-  "tutor>=22.0.0,<23.0.0",
+  "tutor>=23.0.0,<24.0.0",
 ]
 
 dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
-  "tutor[dev]>=22.0.0,<23.0.0",
+  "tutor[dev]>=23.0.0,<24.0.0",
   "ruff",
 ]
 


### PR DESCRIPTION
Tutor's `main` branch now carries the version of the upcoming Open edX release (overhangio/tutor#1483), so this plugin's `main` branch can declare what it actually targets: `tutor>=23.0.0,<24.0.0` instead of the released range. Sibling plugin pins move with it where present.

This is not cosmetic. While the requirement names the released version, `tutor plugins install` and `pip install tutor[full]` resolve it by installing that release over the Tutor under development, which reverts the app name from `tutor-main` to `tutor` and leaves every later command failing with "Project root does not exist".

The test workflow installs Tutor from its main branch before the plugin, because the new requirement has no PyPI release to resolve against until Willow is cut.

The plugin's own version is deliberately left alone: plugins have no version suffix, so bumping it on `main` would make every forward port of a patch release conflict in `__about__.py`.

Part of overhangio/tutor#1294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)